### PR TITLE
Add streaming

### DIFF
--- a/.idea/http-client.iml
+++ b/.idea/http-client.iml
@@ -74,6 +74,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/hamcrest/hamcrest-php" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/mockery/mockery" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/php-stubs/wordpress-stubs" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/mikey179/vfsstream" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -88,6 +88,7 @@
       <path value="$PROJECT_DIR$/vendor/antecedent/patchwork" />
       <path value="$PROJECT_DIR$/vendor/hamcrest/hamcrest-php" />
       <path value="$PROJECT_DIR$/vendor/php-stubs/wordpress-stubs" />
+      <path value="$PROJECT_DIR$/vendor/mikey179/vfsstream" />
     </include_path>
   </component>
   <component name="PhpInterpreters">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.1.0-alpha1] - 2023-08-18
 ### Added
 - `Client` implementation, with tests (#1).
+- Streaming mode that uses a proxy file (#2).

--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ use WpOop\HttpClient\Client;
 // Set up the client with WP request options
 // https://developer.wordpress.org/reference/classes/wp_http/request/
 $client = new Client(
+    // Default args to WP_Http::request()
     [
-    'redirection' => 2,
-    'timeout' => 60,
+        'redirection' => 2,
+        'timeout' => 60,
     ],
-    $responseFactory
+    $responseFactory,
+    // Path to proxy file dir to enable response streaming.
+    // If null, will buffer in memory instead.
+    get_temp_dir() 
 );
 
 // Create a PSR-7 request in any way you want, for example via a PSR-17 factory

--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use WpOop\HttpClient\Client;
 
 /** @var RequestFactoryInterface $requestFactory */
-/** @var ResponseFactoryInterface $responseFacory */
+/** @var ResponseFactoryInterface $responseFactory */
 
 // Set up the client with WP request options
 // https://developer.wordpress.org/reference/classes/wp_http/request/
-$client = new Client([
+$client = new Client(
+    [
     'redirection' => 2,
     'timeout' => 60,
-], $responseFacory);
+    ],
+    $responseFactory
+);
 
 // Create a PSR-7 request in any way you want, for example via a PSR-17 factory
 $request = $requestFactory->createRequest('GET', 'http://somesite.com/api');

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "johnpbloch/wordpress-core": "6.3",
     "php-stubs/wordpress-stubs": "6.3",
     "nyholm/psr7": "^1.7",
-    "brain/monkey": "^2.6.1"
+    "brain/monkey": "^2.6.1",
+    "mikey179/vfsstream": "^1.6.11"
   },
   "suggest": {
     "nyholm/psr7": "A slim and efficient PSR-7 and PSR-17 implementation"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a27055950ed3d947f4dcf03631c67c4",
+    "content-hash": "0bd7b579789eb5a0cd60b9abc53de40a",
     "packages": [
         {
             "name": "nyholm/psr7",
@@ -1201,17 +1201,69 @@
             "time": "2023-08-10T16:07:25+00:00"
         },
         {
+            "name": "mikey179/vfsstream",
+            "version": "v1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "7a20ce2980b8e29a11e233645071cee862b2d5d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/7a20ce2980b8e29a11e233645071cee862b2d5d0",
+                "reference": "7a20ce2980b8e29a11e233645071cee862b2d5d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "bovigo\\vfs\\": "src",
+                    "org\\bovigo\\vfs\\": "org/bovigo/vfs"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
+            "time": "2022-02-23T02:27:25+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e"
+                "reference": "fab5c135e23fdf40ef7d0e58489a18f581b05e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/b8e0bb7d8c604046539c1115994632c74dcb361e",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/fab5c135e23fdf40ef7d0e58489a18f581b05e34",
+                "reference": "fab5c135e23fdf40ef7d0e58489a18f581b05e34",
                 "shasum": ""
             },
             "require": {
@@ -1284,7 +1336,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-08-09T00:03:52+00:00"
+            "time": "2023-08-23T09:14:03+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1842,12 +1894,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "89c4446bd73dd2e600d559489cef3516daa89f90"
+                "reference": "a74e6341296fe533cb69c8c94193afc7537443ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/89c4446bd73dd2e600d559489cef3516daa89f90",
-                "reference": "89c4446bd73dd2e600d559489cef3516daa89f90",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a74e6341296fe533cb69c8c94193afc7537443ec",
+                "reference": "a74e6341296fe533cb69c8c94193afc7537443ec",
                 "shasum": ""
             },
             "require": {
@@ -1912,7 +1964,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-14T13:28:25+00:00"
+            "time": "2023-08-21T05:57:35+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2157,16 +2209,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.10",
+            "version": "9.6.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
+                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
-                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/810500e92855eba8a7a5319ae913be2da6f957b0",
+                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0",
                 "shasum": ""
             },
             "require": {
@@ -2240,7 +2292,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.11"
             },
             "funding": [
                 {
@@ -2256,7 +2308,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-10T04:04:23+00:00"
+            "time": "2023-08-19T07:10:56+00:00"
         },
         {
             "name": "psr/container",
@@ -3451,12 +3503,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "a813c38729aef0034ff7b0f5f0ac54e94ea76804"
+                "reference": "b0ecdf10fa5a15bbf341b6dd75d1b23bd803aaaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a813c38729aef0034ff7b0f5f0ac54e94ea76804",
-                "reference": "a813c38729aef0034ff7b0f5f0ac54e94ea76804",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b0ecdf10fa5a15bbf341b6dd75d1b23bd803aaaf",
+                "reference": "b0ecdf10fa5a15bbf341b6dd75d1b23bd803aaaf",
                 "shasum": ""
             },
             "require": {
@@ -3501,7 +3553,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-08-06T23:03:57+00:00"
+            "time": "2023-08-27T15:25:51+00:00"
         },
         {
             "name": "symfony/console",
@@ -3798,7 +3850,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3880,7 +3932,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -3965,7 +4017,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4049,7 +4101,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4129,7 +4181,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4213,7 +4265,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/1.x"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4456,12 +4508,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "bf8e150f8ff4199171c1ea6ca88bbf1f27b14c66"
+                "reference": "cc7ed9586ee82bfe758318ace243c9f1c6f530eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/bf8e150f8ff4199171c1ea6ca88bbf1f27b14c66",
-                "reference": "bf8e150f8ff4199171c1ea6ca88bbf1f27b14c66",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cc7ed9586ee82bfe758318ace243c9f1c6f530eb",
+                "reference": "cc7ed9586ee82bfe758318ace243c9f1c6f530eb",
                 "shasum": ""
             },
             "require": {
@@ -4558,7 +4610,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm/tree/5.x"
             },
-            "time": "2023-08-17T20:23:23+00:00"
+            "time": "2023-08-28T10:06:45+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
The WP HTTP API does not support direct streaming of any kind. But for responses, it supports streaming to a file. This client can now return a stream to that file.